### PR TITLE
use `getEloquentQuery()` instead of `getModel()`

### DIFF
--- a/src/Overlook.php
+++ b/src/Overlook.php
@@ -49,7 +49,7 @@ class Overlook extends Widget
             if ($res->canViewAny()) {
                 return [
                     'name' => ucfirst($res->getPluralModelLabel()),
-                    'count' => $model::count(),
+                    'count' => $res::getEloquentQuery()->count(),
                     'icon' => invade($res)->getNavigationIcon(),
                     'url' => $res->getUrl('index'),
                 ];

--- a/src/Overlook.php
+++ b/src/Overlook.php
@@ -44,7 +44,6 @@ class Overlook extends Widget
             return ! in_array($resource, $this->getExcludes());
         })->transform(function ($resource) {
             $res = app($resource);
-            $model = $res->getModel();
 
             if ($res->canViewAny()) {
                 return [


### PR DESCRIPTION
# Why?!
because we always override `getElqounetQuery` to customize data.

# Usage
to use it before it gets merged

```json
        "awcodes/overlook": "dev-patch-1",
```

```json
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/Saifallak/overlook.git"
        }
    ],
```