### PR TITLE
Replace bcdiv with NumberFormatter in convertCount method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "filament/filament": "^2.0",
         "spatie/laravel-package-tools": "^1.13.5",
-        "ext-bcmath": "*"
+        "ext-intl": "*"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Overlook.php
+++ b/src/Overlook.php
@@ -71,7 +71,7 @@ class Overlook extends Widget
     {
         if (config('overlook.should_convert_count')) {
             $formatter = new \NumberFormatter(
-                'en_US',
+                app()->getLocale(),
                 \NumberFormatter::PADDING_POSITION,
             );
 

--- a/src/Overlook.php
+++ b/src/Overlook.php
@@ -70,18 +70,12 @@ class Overlook extends Widget
     public function convertCount(string $number): string
     {
         if (config('overlook.should_convert_count')) {
-            $formattedNum = match (true) {
-                strlen($number) >= 13 => bcdiv($number, '1000000000000', 1) . 'T',
-                strlen($number) >= 10 => bcdiv($number, '1000000000', 1) . 'B',
-                strlen($number) >= 7 => bcdiv($number, '1000000', 1) . 'M',
-                strlen($number) >= 4 => bcdiv($number, '1000', 1) . 'K',
-                default => $number,
-            };
+            $formatter = new \NumberFormatter(
+                'en_US',
+                \NumberFormatter::PADDING_POSITION,
+            );
 
-            // Remove .0 from numbers like 1.0 as it's not needed for counts
-            $formattedNum = str_replace('.0', '', $formattedNum);
-
-            return $formattedNum;
+            return $formatter->format($number);
         }
 
         return $number;


### PR DESCRIPTION
This PR is to replace the `bcdiv` with `NumberFormatter` which providers a cleaner syntax. Also should mention that `NumberFormatter` requires `intl` extension, which is more commonly installed than `bcmath` so it's a better option in that regard as well.

100% of credit goes to Adam ( @awcodes )