### PR TITLE
Fix convert count logic.

### DIFF
--- a/src/Widgets/OverlookWidget.php
+++ b/src/Widgets/OverlookWidget.php
@@ -49,7 +49,7 @@ class OverlookWidget extends Widget
             return Number::abbreviate((int) $number);
         }
 
-        return $number;
+        return $this->formatRawCount($number);
     }
 
     public function formatRawCount(string|int|float $number): string


### PR DESCRIPTION
```
public function convertCount(string|int|float $number): string
{
    if (OverlookPlugin::get()->shouldAbbreviateCount()) { // <== false <== OverlookPlugin::make()->abbreviateCount(false)
        return Number::abbreviate((int) $number);
    }

    return $number; // expected to be string per function definition, but string|int|float returned.
}
```